### PR TITLE
Add authorization header to accepted headers

### DIFF
--- a/server/util/cors_handler.go
+++ b/server/util/cors_handler.go
@@ -12,7 +12,7 @@ func NewCorsHandler(handler http.Handler, allowOrigins []string) http.Handler {
 		AllowedOrigins:   allowOrigins,
 		AllowCredentials: true,
 		AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE"},
-		AllowedHeaders:   []string{"Access-Control-Allow-Origin", "Content-Type", "Accept"},
+		AllowedHeaders:   []string{"Access-Control-Allow-Origin", "Content-Type", "Accept", "Authorization"},
 		Debug:            false,
 	})
 


### PR DESCRIPTION
When I tried to retrieve/send the data to server, I faced the error `Response to preflight request doesn't pass access control check`. I supposed that the error caused by `AllowedHeaders` not including `Authorization` Header key. So I added the `Authorization` into `AllowedHeaders`.
