### PR TITLE
Add https://api.torinos.io to AllowedOrigins

### DIFF
--- a/data/config/production.yml
+++ b/data/config/production.yml
@@ -1,0 +1,3 @@
+Cors:
+  AllowedOrigins:
+    - https://api.torinos.io


### PR DESCRIPTION
I forgot to add `https://api.torinos.io` into AllowedOrigins.